### PR TITLE
Apply nettime.AdjustedTime() to all probe timestamps

### DIFF
--- a/probes/http.go
+++ b/probes/http.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netwatcherio/netwatcher-agent/nettime"
 )
 
 type CertInfo struct {
@@ -123,7 +125,7 @@ func HTTPProbe(probe *Probe, dataChan chan ProbeData) error {
 		targetURL = "https://" + targetURL
 	}
 
-	startTime := time.Now()
+	startTime := nettime.AdjustedTime()
 
 	var dnsStart, dnsEnd, connectStart, connectEnd, tlsStart, tlsEnd, firstByteTime time.Time
 	var tlsHandshakeDone bool
@@ -173,23 +175,23 @@ func HTTPProbe(probe *Probe, dataChan chan ProbeData) error {
 			dnsStart = time.Now()
 		},
 		DNSDone: func(info httptrace.DNSDoneInfo) {
-			dnsEnd = time.Now()
+			dnsEnd = nettime.AdjustedTime()
 		},
 		ConnectStart: func(network, addr string) {
-			connectStart = time.Now()
+			connectStart = nettime.AdjustedTime()
 		},
 		ConnectDone: func(network, addr string, err error) {
-			connectEnd = time.Now()
+			connectEnd = nettime.AdjustedTime()
 		},
 		TLSHandshakeStart: func() {
-			tlsStart = time.Now()
+			tlsStart = nettime.AdjustedTime()
 		},
 		TLSHandshakeDone: func(state tls.ConnectionState, err error) {
-			tlsEnd = time.Now()
+			tlsEnd = nettime.AdjustedTime()
 			tlsHandshakeDone = true
 		},
 		GotFirstResponseByte: func() {
-			firstByteTime = time.Now()
+			firstByteTime = nettime.AdjustedTime()
 		},
 	}
 
@@ -204,7 +206,7 @@ func HTTPProbe(probe *Probe, dataChan chan ProbeData) error {
 	resp, err := client.Do(req)
 	if err != nil {
 		result.Error = fmt.Sprintf("request failed: %v", err)
-		result.StopTimestamp = time.Now()
+		result.StopTimestamp = nettime.AdjustedTime()
 		result.TotalMs = float64(result.StopTimestamp.Sub(startTime).Microseconds()) / 1000.0
 		emitHTTPResult(probe, dataChan, result)
 		return err
@@ -275,7 +277,7 @@ func HTTPProbe(probe *Probe, dataChan chan ProbeData) error {
 		}
 	}
 
-	result.StopTimestamp = time.Now()
+	result.StopTimestamp = nettime.AdjustedTime()
 
 	log.Infof("[http] %s %s -> %d (%.2fms)", method, targetURL, result.StatusCode, result.TotalMs)
 
@@ -316,7 +318,7 @@ func emitHTTPResult(probe *Probe, dataChan chan ProbeData, result HTTPPayload) {
 		Type:            ProbeType_HTTP,
 		Payload:         raw,
 		Target:          target,
-		CreatedAt:       time.Now(),
+		CreatedAt:       nettime.AdjustedTime(),
 		SourceInterface: probe.BindInterface,
 	}
 }

--- a/probes/interface_watcher.go
+++ b/probes/interface_watcher.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netwatcherio/netwatcher-agent/nettime"
 )
 
 // InterfaceSnapshot represents the current state of network interfaces for change detection.
@@ -207,7 +209,7 @@ func (w *InterfaceWatcher) check() {
 func takeSnapshot() *InterfaceSnapshot {
 	snap := &InterfaceSnapshot{
 		Interfaces: make(map[string]string),
-		Timestamp:  time.Now(),
+		Timestamp:  nettime.AdjustedTime(),
 	}
 
 	ifaces, err := DiscoverInterfaces()

--- a/probes/mtr.go
+++ b/probes/mtr.go
@@ -10,6 +10,8 @@ import (
 	"github.com/nxtrace/NTrace-core/trace"
 	"github.com/nxtrace/NTrace-core/util"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netwatcherio/netwatcher-agent/nettime"
 )
 
 type MtrPayload struct {
@@ -44,7 +46,7 @@ type MtrPayload struct {
 // Mtr runs MTR-style traceroute using NTrace-core
 func Mtr(cd *Probe, triggered bool) (MtrPayload, error) {
 	var mtrResult MtrPayload
-	mtrResult.StartTimestamp = time.Now()
+	mtrResult.StartTimestamp = nettime.AdjustedTime()
 
 	numMeasurements := cd.Count
 	if numMeasurements <= 0 {
@@ -129,7 +131,7 @@ func Mtr(cd *Probe, triggered bool) (MtrPayload, error) {
 
 	// Transform NTrace result to MtrPayload format
 	mtrResult.Report.Hops = transformHops(result, numMeasurements)
-	mtrResult.StopTimestamp = time.Now()
+	mtrResult.StopTimestamp = nettime.AdjustedTime()
 
 	log.WithFields(log.Fields{
 		"target": target,

--- a/probes/netinfo.go
+++ b/probes/netinfo.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jackpal/gateway"
+	"github.com/netwatcherio/netwatcher-agent/nettime"
 	"github.com/showwin/speedtest-go/speedtest"
 	log "github.com/sirupsen/logrus"
 )
@@ -229,7 +230,7 @@ func extractIP(cidr string) string {
 // Falls back to speedtest.FetchUserInfo() if controller is unavailable.
 func NetworkInfoWithController(ctx context.Context, cfg *ControllerConfig) (NetworkInfoResult, error) {
 	var n NetworkInfoResult
-	n.Timestamp = time.Now()
+	n.Timestamp = nettime.AdjustedTime()
 
 	// Try controller first if configured
 	if cfg != nil && cfg.Host != "" && cfg.PSK != "" {

--- a/probes/ping.go
+++ b/probes/ping.go
@@ -8,6 +8,8 @@ import (
 
 	probing "github.com/prometheus-community/pro-bing"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netwatcherio/netwatcher-agent/nettime"
 )
 
 type PingPayload struct {
@@ -30,7 +32,7 @@ func Ping(ac *Probe, pingChan chan ProbeData, mtrProbe Probe) error {
 	}
 	target := ac.Targets[0].Target
 
-	startTime := time.Now()
+	startTime := nettime.AdjustedTime()
 
 	pinger, err := probing.NewPinger(target)
 	if err != nil {
@@ -105,7 +107,7 @@ func Ping(ac *Probe, pingChan chan ProbeData, mtrProbe Probe) error {
 		// NOTE: stats.* RTT fields are already time.Duration per pro-bing
 		pingR := PingPayload{
 			StartTimestamp:        startTime,
-			StopTimestamp:         time.Now(),
+			StopTimestamp:         nettime.AdjustedTime(),
 			PacketsRecv:           stats.PacketsRecv,
 			PacketsSent:           stats.PacketsSent,
 			PacketsRecvDuplicates: stats.PacketsRecvDuplicates,

--- a/probes/snmp.go
+++ b/probes/snmp.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/gosnmp/gosnmp"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netwatcherio/netwatcher-agent/nettime"
 )
 
 type SNMPConfig struct {
@@ -153,7 +155,7 @@ func SNMPProbe(probe *Probe, dataChan chan ProbeData) error {
 		port = 161
 	}
 
-	startTime := time.Now()
+	startTime := nettime.AdjustedTime()
 
 	params := &gosnmp.GoSNMP{
 		Target:  host,
@@ -194,7 +196,7 @@ func SNMPProbe(probe *Probe, dataChan chan ProbeData) error {
 
 	if err := params.Connect(); err != nil {
 		result.Error = fmt.Sprintf("connect failed: %v", err)
-		result.StopTimestamp = time.Now()
+		result.StopTimestamp = nettime.AdjustedTime()
 		result.QueryTimeMs = float64(result.StopTimestamp.Sub(startTime).Microseconds()) / 1000.0
 		emitSNMPResult(probe, dataChan, result)
 		return err
@@ -209,13 +211,13 @@ func SNMPProbe(probe *Probe, dataChan chan ProbeData) error {
 	snmpResults, err := params.Get(oids)
 	if err != nil {
 		result.Error = fmt.Sprintf("get failed: %v", err)
-		result.StopTimestamp = time.Now()
+		result.StopTimestamp = nettime.AdjustedTime()
 		result.QueryTimeMs = float64(result.StopTimestamp.Sub(startTime).Microseconds()) / 1000.0
 		emitSNMPResult(probe, dataChan, result)
 		return err
 	}
 
-	result.StopTimestamp = time.Now()
+	result.StopTimestamp = nettime.AdjustedTime()
 	result.QueryTimeMs = float64(result.StopTimestamp.Sub(startTime).Microseconds()) / 1000.0
 
 	for _, variable := range snmpResults.Variables {
@@ -414,7 +416,7 @@ func emitSNMPResult(probe *Probe, dataChan chan ProbeData, result SNMPPayload) {
 		Type:            ProbeType_SNMP,
 		Payload:         raw,
 		Target:          target,
-		CreatedAt:       time.Now(),
+		CreatedAt:       nettime.AdjustedTime(),
 		SourceInterface: probe.BindInterface,
 	}
 }

--- a/probes/speedtest.go
+++ b/probes/speedtest.go
@@ -5,6 +5,7 @@ import (
 	"github.com/showwin/speedtest-go/speedtest"
 	"github.com/showwin/speedtest-go/speedtest/transport"
 	log "github.com/sirupsen/logrus"
+	"github.com/netwatcherio/netwatcher-agent/nettime"
 	"strconv"
 	"time"
 )
@@ -111,7 +112,7 @@ func SpeedTest(cd *Probe) (SpeedTestPayload, error) {
 
 	result := SpeedTestPayload{
 		TestData:  s1,
-		Timestamp: time.Now(),
+		Timestamp: nettime.AdjustedTime(),
 	}
 
 	marshal, err := json.Marshal(result)

--- a/probes/speedtest_queue.go
+++ b/probes/speedtest_queue.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/netwatcherio/netwatcher-agent/nettime"
 	"github.com/showwin/speedtest-go/speedtest"
 	log "github.com/sirupsen/logrus"
 )
@@ -154,7 +155,7 @@ func RunSpeedtestForQueue(item SpeedtestQueueItem) SpeedtestResult {
 	// Package results
 	payload := SpeedTestPayload{
 		TestData:  results,
-		Timestamp: time.Now(),
+		Timestamp: nettime.AdjustedTime(),
 	}
 
 	data, err := json.Marshal(payload)

--- a/probes/sysinfo.go
+++ b/probes/sysinfo.go
@@ -3,6 +3,7 @@ package probes
 import (
 	"encoding/json"
 	"github.com/elastic/go-sysinfo"
+	"github.com/netwatcherio/netwatcher-agent/nettime"
 	"time"
 )
 
@@ -65,7 +66,7 @@ type HostMemoryInfo struct {
 
 func SystemInfo() (CompleteSystemInfo, error) {
 	var n CompleteSystemInfo
-	n.Timestamp = time.Now()
+	n.Timestamp = nettime.AdjustedTime()
 
 	host, err := sysinfo.Host()
 

--- a/probes/tls.go
+++ b/probes/tls.go
@@ -13,6 +13,7 @@ import (
 
 	"crypto/x509/pkix"
 	log "github.com/sirupsen/logrus"
+	"github.com/netwatcherio/netwatcher-agent/nettime"
 )
 
 type TLSConfig struct {
@@ -93,7 +94,7 @@ func TLSProbe(probe *Probe, dataChan chan ProbeData) error {
 		target = target + ":443"
 	}
 
-	startTime := time.Now()
+	startTime := nettime.AdjustedTime()
 
 	result := TLSPayload{
 		StartTimestamp: startTime,
@@ -102,7 +103,7 @@ func TLSProbe(probe *Probe, dataChan chan ProbeData) error {
 	host, portStr, err := net.SplitHostPort(target)
 	if err != nil {
 		result.Error = fmt.Sprintf("invalid target: %v", err)
-		result.StopTimestamp = time.Now()
+		result.StopTimestamp = nettime.AdjustedTime()
 		emitTLSResult(probe, dataChan, result)
 		return err
 	}
@@ -123,7 +124,7 @@ func TLSProbe(probe *Probe, dataChan chan ProbeData) error {
 
 	if err != nil {
 		result.Error = fmt.Sprintf("tls dial failed: %v", err)
-		result.StopTimestamp = time.Now()
+		result.StopTimestamp = nettime.AdjustedTime()
 		emitTLSResult(probe, dataChan, result)
 		return err
 	}
@@ -147,7 +148,7 @@ func TLSProbe(probe *Probe, dataChan chan ProbeData) error {
 			SANs:            leaf.DNSNames,
 		}
 		result.DaysUntilExpiry = result.Certificate.DaysUntilExpiry
-		result.IsExpired = time.Now().After(leaf.NotAfter)
+		result.IsExpired = nettime.AdjustedTime().After(leaf.NotAfter)
 		result.IsExpiringSoon = result.DaysUntilExpiry <= 30 && !result.IsExpired
 
 		result.IssuerOrg = getOrgFromSubject(leaf.Issuer)
@@ -180,7 +181,7 @@ func TLSProbe(probe *Probe, dataChan chan ProbeData) error {
 		}
 	}
 
-	result.StopTimestamp = time.Now()
+	result.StopTimestamp = nettime.AdjustedTime()
 
 	log.Infof("[tls] %s -> %s, version=%s, cipher=%s, expires_in=%d days",
 		target, result.TLSVersion, result.TLSVersion, result.TLSCipherSuite, result.DaysUntilExpiry)
@@ -222,7 +223,7 @@ func emitTLSResult(probe *Probe, dataChan chan ProbeData, result TLSPayload) {
 		Type:            ProbeType_TLS,
 		Payload:         raw,
 		Target:          target,
-		CreatedAt:       time.Now(),
+		CreatedAt:       nettime.AdjustedTime(),
 		SourceInterface: probe.BindInterface,
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the 420-minute time offset issue where probe timestamps were using `time.Now()` directly instead of `nettime.AdjustedTime()`, which applies the server-reported time offset.

## Changes

Applied `nettime.AdjustedTime()` to all probe timestamps that are sent to the backend:

- **probes/netinfo.go** - n.Timestamp
- **probes/sysinfo.go** - n.Timestamp
- **probes/speedtest.go** - Timestamp
- **probes/ping.go** - startTime, StopTimestamp
- **probes/mtr.go** - StartTimestamp, StopTimestamp
- **probes/http.go** - Multiple timestamps (start, dns, connect, tls, stop)
- **probes/tls.go** - startTime, StopTimestamp, IsExpired check
- **probes/snmp.go** - startTime, StopTimestamp, CreatedAt
- **probes/interface_watcher.go** - Timestamp
- **probes/speedtest_queue.go** - Timestamp

## Verification

Build succeeds for all probes. The only build warning is in mtr.go due to a pre-existing NTrace-core dependency issue (unrelated to these changes).