### PR TITLE
Fix time sync 401 - add auth headers to SyncTime

### DIFF
--- a/main.go
+++ b/main.go
@@ -247,7 +247,7 @@ func runAgent(ctx context.Context) error {
 		}
 
 		// Sync time with controller on reconnection
-		if err := web.SyncTime(context.Background(), cfg.APIURL); err != nil {
+		if err := web.SyncTime(context.Background(), cfg.APIURL, cfg.WorkspaceID, cfg.AgentID, psk); err != nil {
 			log.Warnf("OnReconnect: time sync failed: %v", err)
 		}
 
@@ -268,7 +268,7 @@ func runAgent(ctx context.Context) error {
 	workers.ProbeDataWorker(wsClient, probeDataCh)
 
 	// Sync time with controller on startup before connecting
-	if err := web.SyncTime(agentCtx, cfg.APIURL); err != nil {
+	if err := web.SyncTime(agentCtx, cfg.APIURL, cfg.WorkspaceID, cfg.AgentID, psk); err != nil {
 		log.Warnf("Startup time sync failed: %v (will retry on reconnect)", err)
 	}
 

--- a/nettime/time_sync.go
+++ b/nettime/time_sync.go
@@ -24,7 +24,7 @@ func absDuration(d time.Duration) time.Duration {
 }
 
 // SyncTime fetches the controller's time and calculates the offset between local and server clocks
-func SyncTime(ctx context.Context, apiURL string) error {
+func SyncTime(ctx context.Context, apiURL string, workspaceID uint, agentID uint, psk string) error {
 	timeURL := apiURL + "/time"
 
 	httpClient := &http.Client{Timeout: 10 * time.Second}
@@ -32,6 +32,10 @@ func SyncTime(ctx context.Context, apiURL string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create time request: %w", err)
 	}
+
+	req.Header.Set("X-Workspace-ID", fmt.Sprintf("%d", workspaceID))
+	req.Header.Set("X-Agent-ID", fmt.Sprintf("%d", agentID))
+	req.Header.Set("X-Agent-PSK", psk)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/web/time_sync.go
+++ b/web/time_sync.go
@@ -24,7 +24,7 @@ func absDuration(d time.Duration) time.Duration {
 }
 
 // SyncTime fetches the controller's time and calculates the offset between local and server clocks
-func SyncTime(ctx context.Context, apiURL string) error {
+func SyncTime(ctx context.Context, apiURL string, workspaceID uint, agentID uint, psk string) error {
 	timeURL := apiURL + "/time"
 
 	httpClient := &http.Client{Timeout: 10 * time.Second}
@@ -32,6 +32,10 @@ func SyncTime(ctx context.Context, apiURL string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create time request: %w", err)
 	}
+
+	req.Header.Set("X-Workspace-ID", fmt.Sprintf("%d", workspaceID))
+	req.Header.Set("X-Agent-ID", fmt.Sprintf("%d", agentID))
+	req.Header.Set("X-Agent-PSK", psk)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

The /time endpoint requires authentication headers (X-Workspace-ID, X-Agent-ID, X-Agent-PSK). Without these, the agent received 401 Unauthorized and time sync failed, causing the 7-hour timestamp offset.

## Changes

- **nettime/time_sync.go**: Add workspaceID, agentID, psk parameters to SyncTime and set auth headers
- **web/time_sync.go**: Same signature update with auth headers  
- **main.go**: Pass auth params to both SyncTime calls (startup + reconnect)

## Root Cause

The time sync was failing with:
```
Startup time sync failed: time endpoint returned status 401 (will retry on reconnect)
OnReconnect: time sync failed: time endpoint returned status 401
```

Without successful time sync, timeOffset remained 0, so AdjustedTime() = time.Now(), and any timezone discrepancy between agent and server was not corrected.