### PR TITLE
Fix time sync: use correct JSON field server_unix_ms

### DIFF
--- a/nettime/time_sync.go
+++ b/nettime/time_sync.go
@@ -53,7 +53,7 @@ func SyncTime(ctx context.Context, apiURL string, workspaceID uint, agentID uint
 	}
 
 	var timeResp struct {
-		Time int64 `json:"time"` // Unix timestamp in milliseconds
+		Time int64 `json:"server_unix_ms"` // Unix timestamp in milliseconds
 	}
 	if err := json.Unmarshal(body, &timeResp); err != nil {
 		return fmt.Errorf("failed to parse time response: %w", err)

--- a/web/time_sync.go
+++ b/web/time_sync.go
@@ -53,7 +53,7 @@ func SyncTime(ctx context.Context, apiURL string, workspaceID uint, agentID uint
 	}
 
 	var timeResp struct {
-		Time int64 `json:"time"` // Unix timestamp in milliseconds
+		Time int64 `json:"server_unix_ms"` // Unix timestamp in milliseconds
 	}
 	if err := json.Unmarshal(body, &timeResp); err != nil {
 		return fmt.Errorf("failed to parse time response: %w", err)


### PR DESCRIPTION
## Problem

The backend `/api/v1/time` endpoint returns `server_unix_ms` (Unix timestamp in milliseconds), but the agent was expecting `time`:

```json
{
  "server_time": "2026-05-13T22:28:29Z",
  "server_unix_ms": 1945688909024
}
```

The incorrect JSON field name caused `json.Unmarshal` to silently fail, leaving `timeOffset` as 0. This meant `AdjustedTime() == time.Now()` with no offset correction applied.

## Fix

Updated the JSON struct tags in both `nettime/time_sync.go` and `web/time_sync.go`:
- Changed `json:"time"` to `json:"server_unix_ms"`

This allows the agent to correctly parse the server timestamp and apply the correct offset.

## Testing

After this fix, the agent should:
1. Successfully parse `server_unix_ms` from the /time endpoint
2. Calculate the correct offset between local and server time
3. Apply that offset to all probe timestamps