### PR TITLE
Fix time sync: use /api/v1/time endpoint (public)

### DIFF
--- a/nettime/time_sync.go
+++ b/nettime/time_sync.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -25,7 +26,7 @@ func absDuration(d time.Duration) time.Duration {
 
 // SyncTime fetches the controller's time and calculates the offset between local and server clocks
 func SyncTime(ctx context.Context, apiURL string, workspaceID uint, agentID uint, psk string) error {
-	timeURL := apiURL + "/time"
+	timeURL := strings.Replace(apiURL, "/agent", "/api/v1", 1) + "/time"
 
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, timeURL, nil)

--- a/web/time_sync.go
+++ b/web/time_sync.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -25,7 +26,7 @@ func absDuration(d time.Duration) time.Duration {
 
 // SyncTime fetches the controller's time and calculates the offset between local and server clocks
 func SyncTime(ctx context.Context, apiURL string, workspaceID uint, agentID uint, psk string) error {
-	timeURL := apiURL + "/time"
+	timeURL := strings.Replace(apiURL, "/agent", "/api/v1", 1) + "/time"
 
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, timeURL, nil)


### PR DESCRIPTION
## Problem

The backend `/time` endpoint is at `/api/v1/time` (public, no auth required), NOT `/agent/time` which requires PSK authentication.

The agent was incorrectly calling `/agent/time` which requires X-Workspace-ID, X-Agent-ID, X-Agent-PSK headers. Since `/api/v1/time` is public, no auth headers are needed at all.

## Root Cause

Agent builds `APIURL = http://controllerHost/agent` for non-SSL.
Then time_sync.go does: `timeURL := apiURL + "/time"` → `http://controllerHost/agent/time` (requires PSK auth)

But the backend time endpoint is at:
```
app.Get("/api/v1/time", func(c *fiber.Ctx) error { ... })
```

## Fix

Replace `/agent` prefix with `/api/v1` when building the time endpoint URL:
```go
timeURL := strings.Replace(apiURL, "/agent", "/api/v1", 1) + "/time