### PR TITLE
Fix time sync: revert to /agent/time endpoint

### DIFF
--- a/nettime/time_sync.go
+++ b/nettime/time_sync.go
@@ -26,7 +26,7 @@ func absDuration(d time.Duration) time.Duration {
 
 // SyncTime fetches the controller's time and calculates the offset between local and server clocks
 func SyncTime(ctx context.Context, apiURL string, workspaceID uint, agentID uint, psk string) error {
-	timeURL := strings.Replace(apiURL, "/agent", "/api/v1", 1) + "/time"
+	timeURL := apiURL + "/time"
 
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, timeURL, nil)

--- a/web/time_sync.go
+++ b/web/time_sync.go
@@ -26,7 +26,7 @@ func absDuration(d time.Duration) time.Duration {
 
 // SyncTime fetches the controller's time and calculates the offset between local and server clocks
 func SyncTime(ctx context.Context, apiURL string, workspaceID uint, agentID uint, psk string) error {
-	timeURL := strings.Replace(apiURL, "/agent", "/api/v1", 1) + "/time"
+	timeURL := apiURL + "/time"
 
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, timeURL, nil)


### PR DESCRIPTION
## Summary

Reverts the time sync URL to use the correct `/agent/time` endpoint.

### Problem

After investigating, the backend has a proper `/agent/time` endpoint that uses PSK authentication (same as login). The previous fix incorrectly tried to use `/api/v1/time` which doesn't exist.

### Solution

- Uses `apiURL + "/time"` → `http://host/agent/time` (correct)
- Auth headers: X-Workspace-ID, X-Agent-ID, X-Agent-PSK
- JSON field: `server_unix_ms`

### Changes

- nettime/time_sync.go: Reverted URL construction
- web/time_sync.go: Reverted URL construction

This works with the new backend `GET /agent/time` endpoint.